### PR TITLE
Update end date variable due to rename

### DIFF
--- a/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
+++ b/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
@@ -127,7 +127,7 @@ extension StoredDosingDecision {
         let lowerTarget = HKQuantity(unit: unit, doubleValue: glucoseTargetRange.minValue)
         let upperTarget = HKQuantity(unit: unit, doubleValue: glucoseTargetRange.maxValue)
         let currentCorrectionRange = CorrectionRange(minValue: lowerTarget, maxValue: upperTarget)
-        let duration = scheduleOverride.duration != .indefinite ? round(scheduleOverride.endDate.timeIntervalSince(date)): nil
+        let duration = scheduleOverride.duration != .indefinite ? round(scheduleOverride.scheduledEndDate.timeIntervalSince(date)): nil
         
         return NightscoutUploadKit.OverrideStatus(name: scheduleOverride.context.name,
                                                   timestamp: date,


### PR DESCRIPTION
I re-named the `endDate` for overrides in my Siri/Overrides/Override History PRs (https://github.com/LoopKit/Loop/pull/1429 & https://github.com/LoopKit/LoopKit/pull/343), so updating `NightscoutService` to reflect the change.