### PR TITLE
Upload mutable doses

### DIFF
--- a/NightscoutServiceKit/NightscoutService.swift
+++ b/NightscoutServiceKit/NightscoutService.swift
@@ -232,7 +232,7 @@ extension NightscoutService: RemoteDataService {
             return
         }
 
-        uploader.createDoses(created.filter { !$0.isMutable } , usingObjectIdCache: self.objectIdCache) { (result) in
+        uploader.createDoses(created, usingObjectIdCache: self.objectIdCache) { (result) in
             switch (result) {
             case .failure(let error):
                 completion(.failure(error))


### PR DESCRIPTION
Filtering of mutable doses was added in a recent commit, which prevents unfinalized doses from being uploaded. Removing the filter allows mutable doses to be uploaded again. Fixes https://github.com/LoopKit/Loop/issues/1652