### PR TITLE
Report automatic bolus in the enacted field of LoopStatus.

### DIFF
--- a/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
+++ b/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
@@ -61,10 +61,16 @@ extension StoredDosingDecision {
     }
     
     var loopStatusEnacted: LoopEnacted? {
-        guard let automaticDoseRecommendation = automaticDoseRecommendation, errors.isEmpty, let tempBasal = automaticDoseRecommendation.basalAdjustment else {
+        guard let automaticDoseRecommendation = automaticDoseRecommendation, errors.isEmpty else {
             return nil
         }
-        return LoopEnacted(rate: tempBasal.unitsPerHour, duration: tempBasal.duration, timestamp: date, received: true, bolusVolume: automaticDoseRecommendation.bolusUnits ?? 0)
+        let tempBasal = automaticDoseRecommendation.basalAdjustment
+        return LoopEnacted(
+            rate: tempBasal?.unitsPerHour,
+            duration: tempBasal?.duration,
+            timestamp: date,
+            received: true,
+            bolusVolume: automaticDoseRecommendation.bolusUnits ?? 0)
     }
 
     var loopStatusFailureReason: String? {


### PR DESCRIPTION
With automatic bolusing in Loop, the last temp basal adjustment might be quite old. The current loop plugin only shows last temp basal adjustment. This change uploads automatic bolus enactments, so the user can have a clearer understanding of the time that Loop last adjusted dosing.

This change will cause rendering errors with the current version of Nightscout, and cause the loop pill to disappear. Needs this patch to work: https://github.com/nightscout/cgm-remote-monitor/pull/7385