### PR TITLE
Fix Remote Bolus OTP validation on Authy

### DIFF
--- a/NightscoutServiceKit/OTPManager.swift
+++ b/NightscoutServiceKit/OTPManager.swift
@@ -70,7 +70,8 @@ public class OTPManager {
     
     private var secretStore: OTPSecretStore
     private var nowDateSource: () -> Date
-    let algorithm: Generator.Algorithm = .sha512
+    let algorithm: Generator.Algorithm = .sha1
+    let issuerName = "Loop"
     var tokenPeriod: TimeInterval
     var passwordDigitCount = 6
     public static var defaultTokenPeriod: TimeInterval = 30
@@ -143,7 +144,7 @@ public class OTPManager {
         }
         
         let generator = Generator(factor: .timer(period: TimeInterval(self.tokenPeriod)), secret: secretKeyData, algorithm: algorithm, digits: passwordDigitCount)!
-        return Token(name: "\(secretKeyName)", issuer: "Loop", generator: generator)
+        return Token(name: secretKeyName, issuer: issuerName, generator: generator)
     }
     
     public func getLastPasswordsAscending(count: Int) -> [String] {
@@ -183,7 +184,7 @@ public class OTPManager {
         let queryItems = [
             URLQueryItem(name: "algorithm", value: algorithm.otpURLStringComponent()),
             URLQueryItem(name: "digits", value: "\(passwordDigitCount)"),
-            URLQueryItem(name: "issuer", value: "Loop"),
+            URLQueryItem(name: "issuer", value: issuerName),
             URLQueryItem(name: "period", value: "\(Int(tokenPeriod))"),
             URLQueryItem(name: "secret", value: secretKey),
         ]


### PR DESCRIPTION
Remote bolus OTP validation was failing on Authy and possibly some other OTP clients. I was specifying the SHA512 algorithm for generating a QR code. The [Google Authenticator spec](https://github.com/google/google-authenticator/wiki/Key-Uri-Format), which I think these OTP standards were derived from, allows either {sha1, sha256, sha512}. However, it seems that Authy only supports SHA1. Some more background is [here](https://github.com/speakeasyjs/speakeasy/issues/95?fbclid=IwAR24tdoNClByDjCX1kh64sD0lyQRBfuXDEXQxtgFvn3OSjUVo9MQMZ3Dj5U#issuecomment-336642453). Apparently this issue has been around for a long time.

