### PR TITLE
Update OTP tests to use codes from 512 algorithm

### DIFF
--- a/NightscoutServiceKitTests/OTPManagerTestCase.swift
+++ b/NightscoutServiceKitTests/OTPManagerTestCase.swift
@@ -55,7 +55,17 @@ class OTPManagerTestCase: XCTestCase {
     }
     
     func getTestSequence() -> OTPTestSequence {
-        return OTPTestSequence(secretKey: "2IOF4MG5QSAKMIYD6QJKOBZFH2QV2CYG", tokenName: "Test Key", endDate: Date(timeIntervalSince1970: 1628864018.933351), otpAscendingPasswords: ["387356", "373945"])
+        /*
+         To get sequence of OTP codes from an independent source for these tests:
+         
+         1. Go to https://cryptotools.net/otp
+         2. Copy the test secretKey below to website
+         3. Note the Epoch time from site
+         4. Note the next 2 consecutive codes
+         5. Update the endDate below with (epoch time + 30)
+         6. Update codes below
+         */
+        return OTPTestSequence(secretKey: "2IOF4MG5QSAKMIYD6QJKOBZFH2QV2CYG", tokenName: "Test Key", endDate: Date(timeIntervalSince1970: 1655326953), otpAscendingPasswords: ["928595", "278849"])
     }
 }
 


### PR DESCRIPTION
Since we switched to use the SHA512 algorithm for generating OTP codes, the tests have not worked. This updates the data and adds some info on where these were generated from to make it simpler to do in the future, if needed.