### PR TITLE
Improve OTP validation and logging

### DIFF
--- a/NightscoutServiceKit/NightscoutService.swift
+++ b/NightscoutServiceKit/NightscoutService.swift
@@ -333,10 +333,18 @@ extension NightscoutService: RemoteDataService {
     
     public func validatePushNotificationSource(_ notification: [String: AnyObject]) -> Bool {
         guard let otpToValidate = notification["otp"] as? String else {
+            log.error("Missing OTP")
             return false
         }
-
-        return otpManager.validateOTP(otpToValidate: otpToValidate)
+        
+        do {
+            try otpManager.validateOTP(otpToValidate: otpToValidate)
+        } catch {
+            log.error("OTP validation error: %{public}@", String(describing: error))
+            return false
+        }
+        
+        return true
     }
     
     public func fetchStoredTherapySettings(completion: @escaping (Result<(TherapySettings,Date), Error>) -> Void) {


### PR DESCRIPTION

* Add support for a user to tweak code to change the number of OTPs we will support (currently 2). This will help as we try to understand and mitigate Apple's push notification delays.
* Improve OTP error handling.
* Add better logging for the various types of OTP errors the can occur.
* Add new tests and test refactor.