### PR TITLE
Remote bolus/carb sent-date is not always available

### DIFF
--- a/NightscoutServiceKit/NightscoutService.swift
+++ b/NightscoutServiceKit/NightscoutService.swift
@@ -337,15 +337,11 @@ extension NightscoutService: RemoteDataService {
             return .failure(NotificationValidationError.missingOTP)
         }
         
-        guard let deliveryDateString = notification["sent-at"] as? String else {
-            return .failure(NotificationValidationError.missingOTPGenerationDate)
-        }
-        
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions =  [.withInternetDateTime, .withFractionalSeconds]
-        
-        guard let deliveryDate = formatter.date(from: deliveryDateString) else {
-            return .failure(NotificationValidationError.missingOTPGenerationDate)
+        var deliveryDate: Date? = nil
+        if let deliveryDateString = notification["sent-at"] as? String {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions =  [.withInternetDateTime, .withFractionalSeconds]
+            deliveryDate = formatter.date(from: deliveryDateString)
         }
         
         do {
@@ -380,14 +376,11 @@ extension NightscoutService: RemoteDataService {
     
     enum NotificationValidationError: LocalizedError {
         case missingOTP
-        case missingOTPGenerationDate
         
         var errorDescription: String? {
             switch self {
             case .missingOTP:
                 return "Error: Password is required."
-            case .missingOTPGenerationDate:
-                return "Error: Password generation date missing."
             }
         }
     }

--- a/NightscoutServiceKit/OTPManager.swift
+++ b/NightscoutServiceKit/OTPManager.swift
@@ -89,7 +89,7 @@ public class OTPManager {
         }
     }
     
-    public func validatePassword(password: String, deliveryDate: Date) throws {
+    public func validatePassword(password: String, deliveryDate: Date?) throws {
         
         guard password.count == passwordDigitCount else {
             throw OTPValidationError.invalidFormat(otp: password)
@@ -238,7 +238,7 @@ public class OTPManager {
     
     enum OTPValidationError: LocalizedError {
         case missingOTP
-        case expired(deliveryDate: Date, maxOTPsToAccept: Int)
+        case expired(deliveryDate: Date?, maxOTPsToAccept: Int)
         case previouslyUsed(otp: String)
         case incorrectOTP(otp: String)
         case invalidFormat(otp: String)
@@ -249,9 +249,13 @@ public class OTPManager {
             case .missingOTP:
                 return "Error: Password is required."
             case .expired(let deliveryDate, let maxOTPsToAccept):
-                let dateFormatter = DateFormatter()
-                dateFormatter.dateFormat = "h:mm"
-                return String(format: "Error: Password sent at %@ has expired. Only the last %u passwords are accepted. See LoopDocs for troubleshooting.", dateFormatter.string(from: deliveryDate), maxOTPsToAccept)
+                if let deliveryDate = deliveryDate {
+                    let dateFormatter = DateFormatter()
+                    dateFormatter.dateFormat = "h:mm"
+                    return String(format: "Error: Password sent at %@ has expired. Only the last %u passwords are accepted. See LoopDocs for troubleshooting.", dateFormatter.string(from: deliveryDate), maxOTPsToAccept)
+                } else {
+                    return String(format: "Error: Password has expired. See LoopDocs for troubleshooting.", maxOTPsToAccept)
+                }
             case .previouslyUsed(let otp):
                 return "Error: Password \(otp) was already used. Wait for a new password for each command."
             case .invalidFormat(let otp):


### PR DESCRIPTION
A user reported that the recent changes I made to improve error messaging is causing an issue. The "sent-at" date included in push notifications is not being sent from all Nightscout versions that support remote bolus/carbs. The change in this PR is to make that date optional for my error handling. I'm reusing this date to provide better error messaging (age of push) so it is not essential.

https://www.facebook.com/groups/2161109864145506/search?q=remote&filters=eyJycF9jaHJvbm9fc29ydDowIjoie1wibmFtZVwiOlwiY2hyb25vc29ydFwiLFwiYXJnc1wiOlwiXCJ9In0%3D