### PR TITLE
Pin OneTimePassword library to exact commit

### DIFF
--- a/NightscoutService.xcodeproj/project.pbxproj
+++ b/NightscoutService.xcodeproj/project.pbxproj
@@ -1258,8 +1258,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mattrubin/OneTimePassword";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = revision;
+				revision = 8e4022f2852d77240d0a17482cbfe325354aac70;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This will pin the OneTimePassword swift package to an exact commit (The one already in Package.resolved). This will avoid problems if users accidentally click "Update to Latest Package Versions" which will pull the latest OneTimePassword develop branch -- which will break Loop builds.

Once this merges, we will need to run "Update to Latest Package Versions" in the Loop workspace which should update the below file, like the diff I have copied below, to reflect that we point to a commit and not a branch.

`Loop.xcworkspace/xcshareddata/swiftpm/Package.resolved`

```
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattrubin/OneTimePassword",
       "state" : {
-        "branch" : "develop",
         "revision" : "8e4022f2852d77240d0a17482cbfe325354aac70"
       }
```